### PR TITLE
lib: Makefile: allow '~' chars in the uname output

### DIFF
--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -35,4 +35,4 @@ $(LIB_NAME).a: $(OBJS_$(LIB_NAME))
 
 nnio_build.c: nnio_build.c.in
 	sed -e "s~@@NANOIO_GIT_COMMIT@@~$(shell if [ -d $(TOPDIR)/.git ]; then git log -1 --pretty=format:%H | tr -d '\n'; elif [ -f $(TOPDIR)/commit ]; then cat $(TOPDIR)/commit | tr -d '\n'; else echo -n ???????; fi)~" \
-		-e "s~@@NANOIO_BUILD_MACHINE@@~$(shell whoami | tr -d '\n'; echo -n @; uname -a | tr -d '\n')~" < $^ > $@
+		-e "s~@@NANOIO_BUILD_MACHINE@@~$(shell whoami | tr -d '\n'; echo -n @; uname -a | tr -d '\n' | awk '{gsub("~","\\~"); print $0 }')~" < $^ > $@


### PR DESCRIPTION
Since we use '~' as our sed delimeter we run into issues if there is a
'~' found in the output of 'uname -a'. We could potentially use a
different delimeter but that just shifts the problem to a different
character. We therefor escape the '~' characters to allow them to
survive the sed expression without causing an error.

Signed-off-by: Mark Asselstine <mark.asselstine@windriver.com>